### PR TITLE
[Dependency] Kotlin 1.7.20 with Compose

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,9 +4,9 @@ object Dependencies {
     object Versions {
         const val agp = "7.2.2"
         const val compose = "1.2.1"
-        const val composeCompiler = "1.3.0"
+        const val composeCompiler = "1.3.2"
         const val jvmTarget = "11"
-        const val kotlin = "1.7.10"
+        const val kotlin = "1.7.20"
 
         // App
         const val compileSdk = 33
@@ -26,9 +26,9 @@ object Dependencies {
     }
 
     object Compose {
-        const val activity = "androidx.activity:activity-compose:1.5.1"
+        const val activity = "androidx.activity:activity-compose:1.6.0"
         const val material = "androidx.compose.material:material:${Versions.compose}"
-        const val navigation = "androidx.navigation:navigation-compose:2.5.1"
+        const val navigation = "androidx.navigation:navigation-compose:2.5.2"
         const val tooling = "androidx.compose.ui:ui-tooling:${Versions.compose}"
         const val toolingPreview = "androidx.compose.ui:ui-tooling-preview:${Versions.compose}"
         const val ui = "androidx.compose.ui:ui:${Versions.compose}"


### PR DESCRIPTION
## Description

This bumps kotlin to version `1.7.20` and updates the compose dependencies:

- compiler to version `1.3.2`
- activity to version `1.6.0`
- navigation to version `2.5.2`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
