### PR TITLE
[Dependency] Bump Kotlinter to Version 3.12.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,8 +57,16 @@ allprojects {
     }
 
     kotlinter {
-        disabledRules = arrayOf("trailing-comma")
+        disabledRules = arrayOf(
+            "trailing-comma",
+            "trailing-comma-on-call-site",
+            "trailing-comma-on-declaration-site"
+        )
     }
+
+
+//   arrayOf("trailing-comma-on-call-site", "trailing-comma-on-declaration-site")
+
 }
 
 tasks.register<Delete>("clean") {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -17,7 +17,7 @@ object Dependencies {
         // Quality Gates
         const val detekt = "1.21.0"
         const val gradleVersions = "0.42.0"
-        const val kotlinter = "3.11.1"
+        const val kotlinter = "3.12.0"
         const val kover = "0.6.0"
     }
 


### PR DESCRIPTION
## Description

This bumps kotlinter to version `3.12.0`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
