### PR TITLE
[Dependency] Bump AGP to Version 7.3.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ import java.util.Locale
 
 object Dependencies {
     object Versions {
-        const val agp = "7.2.2"
+        const val agp = "7.3.0"
         const val compose = "1.2.1"
         const val composeCompiler = "1.3.2"
         const val jvmTarget = "11"


### PR DESCRIPTION
## Description

This bumps the Android Gradle Plugin to version `7.2.0`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
