### PR TITLE
[Dependency] Bump Androidx Core to Version 1.9.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -22,7 +22,7 @@ object Dependencies {
     }
 
     object Androidx {
-        const val core = "androidx.core:core-ktx:1.8.0"
+        const val core = "androidx.core:core-ktx:1.9.0"
     }
 
     object Compose {


### PR DESCRIPTION
## Description

This bumps androidx core to version 1.9.0

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
