### PR TITLE
[Housekeeping] Exclude Generated Classes from Coverage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,13 @@ allprojects {
     }
 
     koverMerged {
+        filters {
+            classes {
+                excludes += listOf(
+                    "*BuildConfig",
+                )
+            }
+        }
         xmlReport {
             onCheck.set(false)
             reportFile.set(layout.buildDirectory.file("$buildDir/reports/kover/result.xml"))


### PR DESCRIPTION
## Description

This excludes the generated `BuildConfig` classes from coverage reports

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
