### PR TITLE
[Housekeeping] Move Package Naming From Manifest to Gradle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,6 +71,7 @@ android {
             }
         }
     }
+    namespace = "com.hello.curiosity.curiosity"
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.hello.curiosity.curiosity">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"

--- a/curiosity/build.gradle.kts
+++ b/curiosity/build.gradle.kts
@@ -64,6 +64,7 @@ android {
             }
         }
     }
+    namespace = "com.hello.curiosity.compose"
 }
 
 dependencies {

--- a/curiosity/src/main/AndroidManifest.xml
+++ b/curiosity/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.hello.curiosity.compose" />
+<manifest />

--- a/test-compose-utils/build.gradle.kts
+++ b/test-compose-utils/build.gradle.kts
@@ -40,6 +40,7 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = Dependencies.Versions.composeCompiler
     }
+    namespace = "com.hello.curiosity.test.compose"
 }
 
 dependencies {

--- a/test-compose-utils/src/main/AndroidManifest.xml
+++ b/test-compose-utils/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.hello.curiosity.test.compose" />
+<manifest />


### PR DESCRIPTION
## Description

This moves the manifest package namespace to the `build.gradle` as per the `AGP 7.3.0`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
