### PR TITLE
[CI/CD] Auto Publishing

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -28,10 +28,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Major Version Bump
         if: ${{ contains(github.event.*.labels.*.name, 'major :1st_place_medal:') }}
-        run: make version BUMP=major
+        run: make release BUMP=major
       - name: Minor Version Bump
         if: ${{ contains(github.event.*.labels.*.name, 'minor :2nd_place_medal:') }}
-        run: make version BUMP=minor
+        run: make release BUMP=minor
       - name: Patch Version Bump
         if: ${{ contains(github.event.*.labels.*.name, 'patch :3rd_place_medal:') }}
-        run: make version BUMP=patch
+        run: make release BUMP=patch

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,37 @@
+name: Release ✈️
+
+on:
+  pull_request:
+    types: [ closed ]
+    branches:
+      - main
+
+jobs:
+  cancel-previous:
+    name: Cancel Publishing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Build
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+  create-release:
+    if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'release :tada:')) }}
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: cancel-previous
+    env:
+      GITHUB_TOKEN: ${{ secrets.AUTO_RELEASE_PAT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Major Version Bump
+        if: ${{ contains(github.event.*.labels.*.name, 'major :1st_place_medal:') }}
+        run: make version BUMP=major
+      - name: Minor Version Bump
+        if: ${{ contains(github.event.*.labels.*.name, 'minor :2nd_place_medal:') }}
+        run: make version BUMP=minor
+      - name: Patch Version Bump
+        if: ${{ contains(github.event.*.labels.*.name, 'patch :3rd_place_medal:') }}
+        run: make version BUMP=patch

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,8 @@ local:
 publish:
 	./scripts/publish.sh ${BUILD_TYPE}
 
+release:
+	./scripts/release.sh ${BUMP}
+
 test:
 	./gradlew test${BUILD_TYPE}UnitTest ${GRADLE_ARGS}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,24 @@
+set -o pipefail
+
+RELEASE_TYPE=${1}
+
+# Get current release version
+git fetch --force --tags
+CURRENT_RELEASE=$(git tag --sort=committerdate | tail -1)
+
+# Separate major, minor and patch numbers
+IFS='.' read -r MAJOR MINOR PATCH <<<"$CURRENT_RELEASE"
+
+# $/${} is unnecessary on arithmetic variables.
+# shellcheck disable=SC2004
+if [[ "${RELEASE_TYPE}" == "major" ]]; then
+  NEW_RELEASE="$(($MAJOR + 1)).0.0"
+elif [ "${RELEASE_TYPE}" == "minor" ]; then
+  NEW_RELEASE="$MAJOR.$(($MINOR + 1)).0"
+else
+  NEW_RELEASE="$MAJOR.$MINOR.$(($PATCH + 1))"
+fi
+
+echo "Bumping version from $CURRENT_RELEASE to $NEW_RELEASE"
+
+gh release create "$NEW_RELEASE" --target "main" --generate-notes


### PR DESCRIPTION
## Description

This will automatically create a release including release notes if the label set to `release 🎉 `. In order to bump the version set either `major 🥇`, `minor 🥈` or `patch 🥉` to automatically bump the version accordingly.

## Example
If the current version is `0.9.0` then:
* `major 🥇` -> `1.0.0`
* `minor 🥈` -> `0.10.0`
* `patch 🥉` -> `0.9.1`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
