### PR TITLE
[Testing] Cover Partials on Text Components

### DIFF
--- a/curiosity/src/test/java/com/hello/curiosity/compose/ui/components/text/ContentLargeTest.kt
+++ b/curiosity/src/test/java/com/hello/curiosity/compose/ui/components/text/ContentLargeTest.kt
@@ -1,6 +1,7 @@
 package com.hello.curiosity.compose.ui.components.text
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.hello.curiosity.compose.ui.ComposeTextTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -8,5 +9,11 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class ContentLargeTest : ComposeTextTest() {
     override val text: String = "Label Text"
-    override val content: @Composable () -> Unit = { ContentLarge(text = text) }
+    override val content: @Composable () -> Unit = {
+        ContentLarge(
+            text = text,
+            modifier = Modifier,
+            textAlign = null,
+        )
+    }
 }

--- a/curiosity/src/test/java/com/hello/curiosity/compose/ui/components/text/ContentMediumTest.kt
+++ b/curiosity/src/test/java/com/hello/curiosity/compose/ui/components/text/ContentMediumTest.kt
@@ -1,6 +1,7 @@
 package com.hello.curiosity.compose.ui.components.text
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.hello.curiosity.compose.ui.ComposeTextTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -8,5 +9,11 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class ContentMediumTest : ComposeTextTest() {
     override val text: String = "Content Text"
-    override val content: @Composable () -> Unit = { ContentMedium(text = text) }
+    override val content: @Composable () -> Unit = {
+        ContentMedium(
+            text = text,
+            modifier = Modifier,
+            textAlign = null,
+        )
+    }
 }

--- a/curiosity/src/test/java/com/hello/curiosity/compose/ui/components/text/LabelLargeTest.kt
+++ b/curiosity/src/test/java/com/hello/curiosity/compose/ui/components/text/LabelLargeTest.kt
@@ -1,6 +1,7 @@
 package com.hello.curiosity.compose.ui.components.text
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.hello.curiosity.compose.ui.ComposeTextTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -8,5 +9,11 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class LabelLargeTest : ComposeTextTest() {
     override val text: String = "Label Text"
-    override val content: @Composable () -> Unit = { LabelLarge(text = text) }
+    override val content: @Composable () -> Unit = {
+        LabelLarge(
+            text = text,
+            modifier = Modifier,
+            textAlign = null,
+        )
+    }
 }

--- a/curiosity/src/test/java/com/hello/curiosity/compose/ui/components/text/LabelMediumTest.kt
+++ b/curiosity/src/test/java/com/hello/curiosity/compose/ui/components/text/LabelMediumTest.kt
@@ -1,6 +1,7 @@
 package com.hello.curiosity.compose.ui.components.text
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.hello.curiosity.compose.ui.ComposeTextTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -8,5 +9,11 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class LabelMediumTest : ComposeTextTest() {
     override val text: String = "Label Text"
-    override val content: @Composable () -> Unit = { LabelMedium(text = text) }
+    override val content: @Composable () -> Unit = {
+        LabelMedium(
+            text = text,
+            modifier = Modifier,
+            textAlign = null,
+        )
+    }
 }

--- a/curiosity/src/test/java/com/hello/curiosity/compose/ui/components/text/LabelSmallTest.kt
+++ b/curiosity/src/test/java/com/hello/curiosity/compose/ui/components/text/LabelSmallTest.kt
@@ -1,6 +1,7 @@
 package com.hello.curiosity.compose.ui.components.text
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.hello.curiosity.compose.ui.ComposeTextTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -8,5 +9,11 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class LabelSmallTest : ComposeTextTest() {
     override val text: String = "Label Text"
-    override val content: @Composable () -> Unit = { LabelSmall(text = text) }
+    override val content: @Composable () -> Unit = {
+        LabelSmall(
+            text = text,
+            modifier = Modifier,
+            textAlign = null,
+        )
+    }
 }


### PR DESCRIPTION
## Description

This is an attempt to cover some of the partial hits caused by default constructors.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
