### PR TITLE
[CI/CD] Exclude Preview from Coverage Reports

### DIFF
--- a/app/src/main/java/com/hello/curiosity/ui/scenes/SettingsScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/SettingsScene.kt
@@ -17,6 +17,7 @@ import com.hello.curiosity.compose.settings.ItemDivider
 import com.hello.curiosity.compose.settings.ItemInfo
 import com.hello.curiosity.compose.settings.ItemSection
 import com.hello.curiosity.compose.settings.ItemToggle
+import com.hello.curiosity.compose.ui.Exclude
 import com.hello.curiosity.ui.theme.AppTheme.lightCyan
 import com.hello.curiosity.ui.theme.AppTheme.metallicSeaweed
 import com.hello.curiosity.ui.theme.toggleColors
@@ -88,6 +89,7 @@ fun SettingsScene() {
     }
 }
 
+@Exclude
 @Preview
 @Composable
 internal fun SettingsScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/color/ColorScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/color/ColorScene.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
+import com.hello.curiosity.compose.ui.Exclude
 
 @Composable
 @Suppress("MagicNumber", "LongMethod")
@@ -73,6 +74,7 @@ internal fun ColorScene() {
     }
 }
 
+@Exclude
 @Preview
 @Composable
 internal fun ColorScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/color/ColorView.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/color/ColorView.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hello.curiosity.compose.ui.Exclude
 
 @Composable
 internal fun ColorView(
@@ -31,6 +32,7 @@ internal fun ColorView(
     Text(text = presentation.title)
 }
 
+@Exclude
 @Preview
 @Composable
 internal fun ColorViewPreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/components/ButtonScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/components/ButtonScene.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hello.curiosity.R
+import com.hello.curiosity.compose.ui.Exclude
 import com.hello.curiosity.compose.ui.components.buttons.IconButton
 import com.hello.curiosity.compose.ui.components.buttons.TextButton
 import com.hello.curiosity.compose.ui.components.buttons.TextIconButton
@@ -87,6 +88,7 @@ fun ButtonScene() {
     }
 }
 
+@Exclude
 @Preview
 @Composable
 fun ButtonScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/components/ComponentScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/components/ComponentScene.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.hello.curiosity.compose.ui.Exclude
 import com.hello.curiosity.compose.ui.components.buttons.TextIconButton
 import com.hello.curiosity.ui.scenes.Scenes
 
@@ -50,6 +51,7 @@ fun ComponentScene(
     }
 }
 
+@Exclude
 @Preview
 @Composable
 fun ComponentScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/components/InputScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/components/InputScene.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hello.curiosity.compose.ui.Exclude
 import com.hello.curiosity.compose.ui.components.input.InputTextField
 import com.hello.curiosity.ui.theme.inputColors
 
@@ -70,6 +71,7 @@ fun InputScene() {
     }
 }
 
+@Exclude
 @Preview
 @Composable
 fun InputScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/components/TextScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/components/TextScene.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hello.curiosity.compose.ui.Exclude
 import com.hello.curiosity.compose.ui.components.text.ContentLarge
 import com.hello.curiosity.compose.ui.components.text.ContentMedium
 import com.hello.curiosity.compose.ui.components.text.LabelLarge
@@ -67,6 +68,7 @@ fun TextScene() {
     }
 }
 
+@Exclude
 @Preview
 @Composable
 fun TextScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/components/ToggleScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/components/ToggleScene.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hello.curiosity.compose.ui.Exclude
 import com.hello.curiosity.compose.ui.components.toggle.CheckBox
 import com.hello.curiosity.compose.ui.components.toggle.Toggle
 import com.hello.curiosity.ui.theme.checkColors
@@ -42,6 +43,7 @@ fun ToggleScene() {
     }
 }
 
+@Exclude
 @Preview
 @Composable
 fun ToggleScenePreview() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/type/TypographyScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/type/TypographyScene.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hello.curiosity.compose.ui.Exclude
 
 @Composable
 @Suppress("LongMethod")
@@ -84,6 +85,7 @@ fun TypographyScene() {
     }
 }
 
+@Exclude
 @Preview
 @Composable
 fun TypographyScenePreview() {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,9 @@ allprojects {
                     "*BuildConfig",
                 )
             }
+            annotations {
+                excludes += listOf("*Preview", "*Exclude")
+            }
         }
         xmlReport {
             onCheck.set(false)

--- a/curiosity/src/main/java/com/hello/curiosity/compose/ui/Exclude.kt
+++ b/curiosity/src/main/java/com/hello/curiosity/compose/ui/Exclude.kt
@@ -1,4 +1,4 @@
-package com.hello.curiosity.compose.settings
+package com.hello.curiosity.compose.ui
 
 @Suppress("EmptyDefaultConstructor")
 annotation class Exclude()

--- a/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/input/InputTextField.kt
+++ b/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/input/InputTextField.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.hello.curiosity.compose.ui.Exclude
 import com.hello.curiosity.compose.ui.components.text.LabelSmall
 import com.hello.curiosity.compose.ui.components.text.LabelTiny
 import com.hello.curiosity.compose.ui.theme.ThemeImpl
@@ -124,6 +125,7 @@ fun InputTextField(
     }
 }
 
+@Exclude
 @Preview
 @Composable
 fun InputTextFieldPreview() {

--- a/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/text/ContentLarge.kt
+++ b/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/text/ContentLarge.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import com.hello.curiosity.compose.ui.Exclude
 
 @Composable
 fun ContentLarge(
@@ -41,6 +42,7 @@ fun ContentLarge(
     style = style
 )
 
+@Exclude
 @Preview
 @Composable
 internal fun ContentLargePreview() {

--- a/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/text/ContentMedium.kt
+++ b/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/text/ContentMedium.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import com.hello.curiosity.compose.ui.Exclude
 
 @Composable
 fun ContentMedium(
@@ -41,6 +42,7 @@ fun ContentMedium(
     style = style
 )
 
+@Exclude
 @Preview
 @Composable
 internal fun ContentMediumPreview() {

--- a/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/text/LabelLarge.kt
+++ b/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/text/LabelLarge.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import com.hello.curiosity.compose.ui.Exclude
 
 @Composable
 fun LabelLarge(
@@ -41,6 +42,7 @@ fun LabelLarge(
     style = style
 )
 
+@Exclude
 @Preview
 @Composable
 internal fun LabelLargePreview() {

--- a/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/text/LabelMedium.kt
+++ b/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/text/LabelMedium.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import com.hello.curiosity.compose.ui.Exclude
 
 @Composable
 fun LabelMedium(
@@ -41,6 +42,7 @@ fun LabelMedium(
     style = style
 )
 
+@Exclude
 @Preview
 @Composable
 internal fun LabelMediumPreview() {

--- a/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/text/LabelSmall.kt
+++ b/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/text/LabelSmall.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import com.hello.curiosity.compose.ui.Exclude
 
 @Composable
 fun LabelSmall(
@@ -41,6 +42,7 @@ fun LabelSmall(
     style = style
 )
 
+@Exclude
 @Preview
 @Composable
 internal fun LabelSmallPreview() {

--- a/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/text/LabelTiny.kt
+++ b/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/text/LabelTiny.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import com.hello.curiosity.compose.ui.Exclude
 
 @Composable
 fun LabelTiny(
@@ -41,6 +42,7 @@ fun LabelTiny(
     style = style
 )
 
+@Exclude
 @Preview
 @Composable
 internal fun LabelTinyPreview() {

--- a/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/toggle/CheckBox.kt
+++ b/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/toggle/CheckBox.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hello.curiosity.compose.R
+import com.hello.curiosity.compose.ui.Exclude
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -63,6 +64,7 @@ fun CheckBox(
     }
 }
 
+@Exclude
 @Preview
 @Composable
 fun CheckboxPreview() {

--- a/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/toggle/Toggle.kt
+++ b/curiosity/src/main/java/com/hello/curiosity/compose/ui/components/toggle/Toggle.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hello.curiosity.compose.ui.Exclude
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -67,6 +68,7 @@ fun Toggle(
     }
 }
 
+@Exclude
 @Preview
 @Composable
 fun TogglePreview() {

--- a/curiosity/src/test/java/com/hello/curiosity/compose/ui/components/text/LabelSmallTest.kt
+++ b/curiosity/src/test/java/com/hello/curiosity/compose/ui/components/text/LabelSmallTest.kt
@@ -18,7 +18,7 @@ class LabelSmallTest : ComposeTextTest() {
     }
 
     override val contentResource: @Composable () -> Unit = {
-        LabelMedium(
+        LabelSmall(
             text = res,
             modifier = Modifier,
             color = Color.White,

--- a/settings/src/main/java/com/hello/curiosity/compose/settings/Exclude.kt
+++ b/settings/src/main/java/com/hello/curiosity/compose/settings/Exclude.kt
@@ -1,0 +1,3 @@
+package com.hello.curiosity.compose.settings
+
+annotation class Exclude()

--- a/settings/src/main/java/com/hello/curiosity/compose/settings/ItemAction.kt
+++ b/settings/src/main/java/com/hello/curiosity/compose/settings/ItemAction.kt
@@ -50,8 +50,9 @@ fun ItemAction(
     )
 }
 
-@Composable
+@Exclude
 @Preview
+@Composable
 internal fun ItemActionPreview() {
     ItemAction(
         title = android.R.string.copy,

--- a/settings/src/main/java/com/hello/curiosity/compose/settings/ItemDivider.kt
+++ b/settings/src/main/java/com/hello/curiosity/compose/settings/ItemDivider.kt
@@ -23,6 +23,7 @@ fun ItemDivider(
     thickness = thickness,
 )
 
+@Exclude
 @Preview
 @Composable
 internal fun ItemDividerPreview() {

--- a/settings/src/main/java/com/hello/curiosity/compose/settings/ItemInfo.kt
+++ b/settings/src/main/java/com/hello/curiosity/compose/settings/ItemInfo.kt
@@ -44,8 +44,9 @@ fun ItemInfo(
     }
 }
 
-@Composable
+@Exclude
 @Preview
+@Composable
 internal fun ItemInfoPreview() {
     ItemInfo(
         title = android.R.string.copy,

--- a/settings/src/main/java/com/hello/curiosity/compose/settings/ItemSection.kt
+++ b/settings/src/main/java/com/hello/curiosity/compose/settings/ItemSection.kt
@@ -28,6 +28,7 @@ fun ItemSection(
     style = style,
 )
 
+@Exclude
 @Preview
 @Composable
 internal fun ItemSectionPreview() {

--- a/settings/src/main/java/com/hello/curiosity/compose/settings/ItemToggle.kt
+++ b/settings/src/main/java/com/hello/curiosity/compose/settings/ItemToggle.kt
@@ -50,6 +50,7 @@ fun ItemToggle(
     )
 }
 
+@Exclude
 @Preview
 @Composable
 internal fun ItemTogglePreview() {


### PR DESCRIPTION
## Description

This is a small workaround to exclude compose previews from coverage reports.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
