### PR TITLE
[Dependency] Bump Ben Manes Gradle Versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,7 +18,7 @@ object Dependencies {
 
         // Quality Gates
         const val detekt = "1.22.0"
-        const val gradleVersions = "0.45.0"
+        const val gradleVersions = "0.46.0"
         const val kotlinter = "3.13.0"
         const val kover = "0.6.1"
     }


### PR DESCRIPTION
## Description

This bumps gradle versions to `0.46.0`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
