### PR TITLE
[Dependency] Bump Kotlin 1.8.10 and Compose Compiler 1.4.3

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,7 +4,7 @@ object Dependencies {
     object Versions {
         const val agp = "7.4.1"
         const val compose = "1.3.3"
-        const val composeCompiler = "1.4.0"
+        const val composeCompiler = "1.4.3"
         const val jvmTarget = "11"
         const val kotlin = "1.8.10"
         const val navigation = "2.5.3"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -6,7 +6,7 @@ object Dependencies {
         const val compose = "1.3.3"
         const val composeCompiler = "1.4.0"
         const val jvmTarget = "11"
-        const val kotlin = "1.8.0"
+        const val kotlin = "1.8.10"
         const val navigation = "2.5.3"
         const val playPublisher = "3.8.1"
 


### PR DESCRIPTION
## Description

This bumps kotlin to version `1.8.10`, and the compose compiler to version `1.4.3`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
