### PR TITLE
[Dependency] AGP Version 7.4.2

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ import java.util.Locale
 
 object Dependencies {
     object Versions {
-        const val agp = "7.4.1"
+        const val agp = "7.4.2"
         const val compose = "1.3.3"
         const val composeCompiler = "1.4.3"
         const val jvmTarget = "11"


### PR DESCRIPTION
## Description

This bumps the android gradle plugin to version `7.4.2`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
