### PR TITLE
[Housekeeping] Namespace Navigation Library

### DIFF
--- a/app/src/main/java/com/hello/curiosity/ui/scenes/DashboardScene.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/DashboardScene.kt
@@ -15,10 +15,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
 import com.hello.curiosity.R
-import com.hello.curiosity.compose.navigation.BottomNavigation
-import com.hello.curiosity.compose.navigation.currentRoute
 import com.hello.curiosity.navigation.CuriosityNavHost
 import io.github.hellocuriosity.compose.ui.components.text.LabelMedium
+import io.github.hellocuriosity.navigation.BottomNavigation
+import io.github.hellocuriosity.navigation.currentRoute
 
 @Composable
 fun DashboardScene() {

--- a/app/src/main/java/com/hello/curiosity/ui/scenes/Scenes.kt
+++ b/app/src/main/java/com/hello/curiosity/ui/scenes/Scenes.kt
@@ -3,7 +3,7 @@ package com.hello.curiosity.ui.scenes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.hello.curiosity.R
-import com.hello.curiosity.compose.navigation.Scene
+import io.github.hellocuriosity.navigation.Scene
 
 sealed class Scenes(
     @StringRes override val title: Int,

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 android {
-    namespace = "com.hello.curiosity.compose.navigation"
+    namespace = "io.github.hellocuriosity.compose.navigation"
     compileSdk = Dependencies.Versions.compileSdk
     buildToolsVersion = Dependencies.Versions.buildToolsVersion
 
@@ -129,7 +129,7 @@ afterEvaluate {
         publications {
             create<MavenPublication>("release") {
                 from(components["release"])
-                groupId = "com.hello.curiosity.compose"
+                groupId = "io.github.hellocuriosity.compose"
                 artifactId = "navigation"
                 version = System.getenv("VERSION") ?: "local"
 

--- a/navigation/src/main/java/io/github/hellocuriosity/navigation/BottomNavigation.kt
+++ b/navigation/src/main/java/io/github/hellocuriosity/navigation/BottomNavigation.kt
@@ -1,4 +1,4 @@
-package com.hello.curiosity.compose.navigation
+package io.github.hellocuriosity.navigation
 
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationDefaults

--- a/navigation/src/main/java/io/github/hellocuriosity/navigation/Scene.kt
+++ b/navigation/src/main/java/io/github/hellocuriosity/navigation/Scene.kt
@@ -1,4 +1,4 @@
-package com.hello.curiosity.compose.navigation
+package io.github.hellocuriosity.navigation
 
 interface Scene {
     val title: Int

--- a/navigation/src/test/java/io/github/hellocuriosity/navigation/BottomNavigationTest.kt
+++ b/navigation/src/test/java/io/github/hellocuriosity/navigation/BottomNavigationTest.kt
@@ -1,4 +1,4 @@
-package com.hello.curiosity.compose.navigation
+package io.github.hellocuriosity.navigation
 
 import android.content.Context
 import androidx.compose.material.Text


### PR DESCRIPTION
## Description

This renames the namespace from `com.hello.curiosity` to `io.github.hellocuriosity` in preparation for publishing on maven central #94. 

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied